### PR TITLE
Make bearer auth per session instead of per request

### DIFF
--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -1,17 +1,6 @@
 import requests
-from requests.auth import AuthBase
 
 from .model import (EntryCreatedRS, OperationCompletionRS)
-
-
-class BearerAuth(AuthBase):
-    """Attaches HTTP Bearer Authentication to the given Request object."""
-    def __init__(self, token):
-        self.token = token
-
-    def __call__(self, r):
-        r.headers["Authorization"] = "bearer {0}".format(self.token)
-        return r
 
 
 class ReportPortalService(object):
@@ -35,8 +24,9 @@ class ReportPortalService(object):
         self.base_url = self.uri_join(self.endpoint,
                                       self.api_base,
                                       self.project)
+
         self.session = requests.Session()
-        self.session.auth = BearerAuth(self.token)
+        self.session.headers["Authorization"] = "bearer {0}".format(self.token)
 
     @staticmethod
     def uri_join(*uri_parts):


### PR DESCRIPTION
Previous commit introduced BearerAuth class.  It adds for each request required auth header (call for each request) which is not necessary in the current implementation because token is not changed during session. Moreover, it performs string formatting operation for each request which is slightly slower.
 - Move auth header to session scope due to reasons described above.