### PR TITLE
Binary attachment support for issue #4

### DIFF
--- a/reportportal_client/model/request.py
+++ b/reportportal_client/model/request.py
@@ -66,21 +66,10 @@ class FinishTestItemRQ(FinishExecutionRQ):
         self.issue = issue
 
 
-class File(RQ):
-    def __init__(self, name, content):
-        super(File, self).__init__()
-        self.name = name
-        self.content = content
-
-
 class SaveLogRQ(RQ):
-    def __init__(self, item_id=None, time=None, message=None, level=None,
-                 file_obj=None):
+    def __init__(self, item_id=None, time=None, message=None, level=None):
         super(SaveLogRQ, self).__init__()
         self.item_id = item_id
         self.time = time
         self.message = message
         self.level = level
-        self.file = None
-        if file_obj is not None:
-            self.file = file_obj.data

--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -1,3 +1,4 @@
+import json
 import requests
 
 from .model import (EntryCreatedRS, OperationCompletionRS)
@@ -71,4 +72,24 @@ class ReportPortalService(object):
     def log(self, save_log_rq):
         url = self.uri_join(self.base_url, "log")
         r = self.session.post(url=url, json=save_log_rq.as_dict())
+        return EntryCreatedRS(raw=r.text)
+
+    def attach(self, save_log_rq, data):
+        """Logs message with attachment.
+
+        Args:
+            save_log_rq: SaveLogRQ instance
+            data:  3-tuple ("filename", fileobj or content, "content_type")
+
+        Returns:
+            An instance of EntryCreatedRS.
+        """
+        url = self.uri_join(self.base_url, "log")
+        dct = save_log_rq.as_dict()
+        dct["file"] = {"name": data[0]}
+        files = {
+            "json_request_part": (None, json.dumps([dct]), "application/json"),
+            "file": data,
+        }
+        r = self.session.post(url=url, files=files)
         return EntryCreatedRS(raw=r.text)

--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -79,7 +79,9 @@ class ReportPortalService(object):
 
         Args:
             save_log_rq: SaveLogRQ instance
-            data:  3-tuple ("filename", fileobj or content, "content_type")
+            data:  2-tuple ("filename", fileobj or content) in this case
+                   "application/octet-stream" will be used by default, or
+                   3-tuple ("filename", fileobj or content, "content_type")
 
         Returns:
             An instance of EntryCreatedRS.
@@ -89,7 +91,8 @@ class ReportPortalService(object):
         dct["file"] = {"name": data[0]}
         files = {
             "json_request_part": (None, json.dumps([dct]), "application/json"),
-            "file": data,
+            "file": (data[0], data[1],
+                     data[2] if len(data) > 2 else "application/octet-stream")
         }
         r = self.session.post(url=url, files=files)
         return EntryCreatedRS(raw=r.text)

--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -74,25 +74,24 @@ class ReportPortalService(object):
         r = self.session.post(url=url, json=save_log_rq.as_dict())
         return EntryCreatedRS(raw=r.text)
 
-    def attach(self, save_log_rq, data):
+    def attach(self, save_log_rq, name, data, mime="application/octet-stream"):
         """Logs message with attachment.
 
         Args:
             save_log_rq: SaveLogRQ instance
-            data:  2-tuple ("filename", fileobj or content) in this case
-                   "application/octet-stream" will be used by default, or
-                   3-tuple ("filename", fileobj or content, "content_type")
+            name: name of attachment
+            data: fileobj or content
+            mime: content type for attachment
 
         Returns:
             An instance of EntryCreatedRS.
         """
         url = self.uri_join(self.base_url, "log")
         dct = save_log_rq.as_dict()
-        dct["file"] = {"name": data[0]}
+        dct["file"] = {"name": name}
         files = {
             "json_request_part": (None, json.dumps([dct]), "application/json"),
-            "file": (data[0], data[1],
-                     data[2] if len(data) > 2 else "application/octet-stream")
+            "file": (name, data, mime)
         }
         r = self.session.post(url=url, files=files)
         return EntryCreatedRS(raw=r.text)


### PR DESCRIPTION
This implementation relies on requests `files` parameter. It means that `data` parameter can be a file-like object or file content.
There are two mandatory parameters:
 - file name of attachment
 - file obj or content

The third `mime` argument can be skipped, in this case content type will be `"application/octet-stream"`.
`agent` implementation modules are responsible for closing file descriptors and providing content for attachment or can use the same approach as is.

Testing example from pytest agent:
```python
with open(file_path, "rb") as fh:
    attach("Test message",  name=basename(filepath), data=fh, mime="image/jpeg")
```
Or if data collected from anywhere, just pass it:
```python
attach("Output of 'ps aux'", "ps-aux.txt", subprocess.check_output(["ps", "aux"]))
```
__The only thing need to check is ability to download attachment or add labels.__
![image](https://cloud.githubusercontent.com/assets/1073415/25952649/ee3b2690-3669-11e7-87a5-f2cdc364fdf8.png)

Because attachment tab does not provide any ability to distinguish similar attachment with this implementation (see bellow).
![image](https://cloud.githubusercontent.com/assets/1073415/25953031/db853da0-366a-11e7-8b09-032d0038d602.png)
