### PR TITLE
Add flag to allow marking skipped as not 'To Investigate' items

### DIFF
--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -86,7 +86,8 @@ def uri_join(*uri_parts):
 class ReportPortalService(object):
     """Service class with report portal event callbacks."""
 
-    def __init__(self, endpoint, project, token, api_base="api/v1"):
+    def __init__(self, endpoint, project, token, api_base="api/v1",
+                 is_skipped_an_issue=True):
         """Init the service class.
 
         Args:
@@ -94,12 +95,15 @@ class ReportPortalService(object):
             project: project name to use for launch names.
             token: authorization token.
             api_base: defaults to api/v1, can be changed to other version.
+            is_skipped_an_issue: option to mark skipped tests as not
+                'To Investigate' items on Server side.
         """
         super(ReportPortalService, self).__init__()
         self.endpoint = endpoint
         self.api_base = api_base
         self.project = project
         self.token = token
+        self.is_skipped_an_issue = is_skipped_an_issue
         self.base_url = uri_join(self.endpoint,
                                  self.api_base,
                                  self.project)
@@ -187,6 +191,11 @@ class ReportPortalService(object):
         return item_id
 
     def finish_test_item(self, end_time, status, issue=None):
+        # check if skipped test should not be marked as "TO INVESTIGATE"
+        if issue is None and status == "SKIPPED" \
+                and not self.is_skipped_an_issue:
+            issue = {"issue_type": "NOT_ISSUE"}
+
         data = {
             "end_time": end_time,
             "status": status,

--- a/reportportal_client/service_async.py
+++ b/reportportal_client/service_async.py
@@ -116,7 +116,8 @@ class ReportPortalServiceAsync(object):
     """
 
     def __init__(self, endpoint, project, token, api_base="api/v1",
-                 error_handler=None, log_batch_size=20):
+                 error_handler=None, log_batch_size=20,
+                 is_skipped_an_issue=True):
         """Init the service class.
 
         Args:
@@ -126,12 +127,14 @@ class ReportPortalServiceAsync(object):
             api_base: defaults to api/v1, can be changed to other version.
             error_handler: function to be called to handle errors occurred
                 during items processing (in thread)
+            is_skipped_an_issue: option to mark skipped tests as not
+                'To Investigate' items on Server side.
         """
         super(ReportPortalServiceAsync, self).__init__()
         self.error_handler = error_handler
         self.log_batch_size = log_batch_size
         self.rp_client = ReportPortalService(
-            endpoint, project, token, api_base)
+            endpoint, project, token, api_base, is_skipped_an_issue)
         self.log_batch = []
         self.supported_methods = ["start_launch", "finish_launch",
                                   "start_test_item", "finish_test_item", "log"]


### PR DESCRIPTION
Add is_skipped_an_issue flag to services to allow uploading skipped
tests items as not 'To Investigate' items on Server side.