### PR TITLE
Retry POSTing logs if KeyError occurs on iterating over env variables

### DIFF
--- a/reportportal_client/__init__.py
+++ b/reportportal_client/__init__.py
@@ -20,3 +20,5 @@ __all__ = (
     ReportPortalService,
     ReportPortalServiceAsync,
 )
+
+POST_LOGBATCH_RETRY_COUNT = 10


### PR DESCRIPTION
addresses #39 
Add a simple retry loop to catch intermittent race condition occurring when py.test unsets `PYTEST_CURRENT_TEST` variable during `urllib`'s iterating over env. variables