### PR TITLE
fix the circular dependency regression on importing POST_LOGBATCH_RETRY_COUNT

### DIFF
--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -20,7 +20,6 @@ import uuid
 import logging
 
 from .errors import ResponseError, EntryCreatedError, OperationCompletionError
-from reportportal_client import POST_LOGBATCH_RETRY_COUNT
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -292,6 +291,7 @@ class ReportPortalService(object):
             )
         )]
         files.extend(attachments)
+        from reportportal_client import POST_LOGBATCH_RETRY_COUNT
         for i in range(POST_LOGBATCH_RETRY_COUNT):
             try:
                 r = self.session.post(


### PR DESCRIPTION
Sorry, i noticed this too late, but the module variable import at the beginning of the `service.py` module was causing a circular depenency error on importing the whole module.

The solution to this is import the variable later in the code.


```python
In [1]: import reportportal_client

In [2]: reportportal_client.POST_LOGBATCH_RETRY_COUNT
Out[2]: 10

In [3]: from reportportal_client import POST_LOGBATCH_RETRY_COUNT

In [4]: POST_LOGBATCH_RETRY_COUNT
Out[4]: 10


```