### PR TITLE
Bump the version up for uploading to PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '3.2.0'
+__version__ = '3.2.0.post1'
 
 setup(
     name='reportportal-client',


### PR DESCRIPTION
This is for https://github.com/reportportal/client-Python/issues/50.

We have to change the version number for the package to upload it to PyPi without issues. The current package at PyPi contains outdated code.

Once this PR is merged, someone who has access to the reportportal-project at PyPi should complete the following steps:
1. Clone repository
Run from the root of the cloned repo:
2. python setup.py sdist
3. twine upload dist/*