### PR TITLE
Allow the value of test item's parameter to be 'unicode'.

### DIFF
--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -19,6 +19,7 @@ import requests
 import uuid
 import logging
 
+import six
 from requests.adapters import HTTPAdapter
 
 from .errors import ResponseError, EntryCreatedError, OperationCompletionError
@@ -189,7 +190,13 @@ class ReportPortalService(object):
             }
         """
         if parameters is not None:
-            parameters = [{"key": key, "value": str(value)}
+            def _str(value):
+                if isinstance(value, six.text_type):
+                    # Don't try to encode 'unicode' in Python 2.
+                    return value
+                return str(value)
+
+            parameters = [{"key": key, "value": _str(value)}
                           for key, value in parameters.items()]
 
         data = {


### PR DESCRIPTION
Hello, `str` will raise error when a unicode value is passed, eg:
```
# coding: utf-8
import pytest


@pytest.mark.parametrize('x', [u'你好'])
def test_it(x):
    pass
```

This patch don't call `str` if value is`six.text_type`, thanks!