### PR TITLE
Adding support for update test item API call

### DIFF
--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -213,6 +213,23 @@ class ReportPortalService(object):
         logger.debug("start_test_item - Stack: %s", self.stack)
         return item_id
 
+    def update_test_item(self, description=None, tags=None):
+        """Update test item.
+
+        :param str description: test item description
+        :param list tags: test item tags
+        """
+        data = {
+            "description": description,
+            "tags": tags,
+        }
+
+        item_id = self.stack[-1]
+        url = uri_join(self.base_url, "item", item_id, "update")
+        r = self.session.put(url=url, json=data, verify=self.verify_ssl)
+        logger.debug("update_test_item - Stack: %s", self.stack)
+        return _get_msg(r)
+
     def finish_test_item(self, end_time, status, issue=None):
         # check if skipped test should not be marked as "TO INVESTIGATE"
         if issue is None and status == "SKIPPED" \

--- a/reportportal_client/service_async.py
+++ b/reportportal_client/service_async.py
@@ -159,7 +159,8 @@ class ReportPortalServiceAsync(object):
             retries)
         self.log_batch = []
         self.supported_methods = ["start_launch", "finish_launch",
-                                  "start_test_item", "finish_test_item", "log"]
+                                  "start_test_item", "update_test_item",
+                                  "finish_test_item", "log"]
 
         self.queue = queue.Queue()
         self.listener = QueueListener(self.queue, self.process_item,
@@ -283,6 +284,20 @@ class ReportPortalServiceAsync(object):
             "parameters": parameters,
         }
         self.queue.put_nowait(("start_test_item", args))
+
+    def update_test_item(self, description=None, tags=None):
+        """Update test item.
+
+        :param str description: test item description
+        :param list tags: test item tags
+        """
+        logger.debug("update_test_item queued")
+
+        args = {
+            "description": description,
+            "tags": tags,
+        }
+        self.queue.put_nowait(("update_test_item", args))
 
     def finish_test_item(self, end_time, status, issue=None):
         logger.debug("finish_test_item queued")


### PR DESCRIPTION
Adding support for API call: `PUT /{projectName}/item/{item}/update`
Model: 
```
UpdateTestItemRQ {
description (string, optional),
tags (Array[string], optional)
}
```