### PR TITLE
Support skipped issue parameter

### DIFF
--- a/reportportal_client/service_async.py
+++ b/reportportal_client/service_async.py
@@ -302,6 +302,11 @@ class ReportPortalServiceAsync(object):
     def finish_test_item(self, end_time, status, issue=None):
         logger.debug("finish_test_item queued")
 
+        # check if skipped test should not be marked as "TO INVESTIGATE"
+        if issue is None and status == "SKIPPED" \
+                and not self.rp_client.is_skipped_an_issue:
+            issue = {"issue_type": "NOT_ISSUE"}
+
         args = {
             "end_time": end_time,
             "status": status,

--- a/reportportal_client/service_async.py
+++ b/reportportal_client/service_async.py
@@ -303,7 +303,8 @@ class ReportPortalServiceAsync(object):
         logger.debug("finish_test_item queued")
 
         # check if skipped test should not be marked as "TO INVESTIGATE"
-        if issue is None and status == "SKIPPED" \
+        to_investigate = issue is None or issue.get("issue_type") == "TI001"
+        if to_investigate and status == "SKIPPED" \
                 and not self.rp_client.is_skipped_an_issue:
             issue = {"issue_type": "NOT_ISSUE"}
 


### PR DESCRIPTION
This is to support https://github.com/reportportal/agent-python-pytest/pull/161
This check, that is present in the synchronous service was missing form the async version.
