### PR TITLE
Code reference bypass

### DIFF
--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -258,6 +258,7 @@ class ReportPortalService(object):
                         parameters=None,
                         parent_item_id=None,
                         has_stats=True,
+                        code_ref=None,
                         **kwargs):
         """
         Item_type can be.
@@ -287,7 +288,8 @@ class ReportPortalService(object):
             "launchUuid": self.launch_id,
             "type": item_type,
             "parameters": parameters,
-            "hasStats": has_stats
+            "hasStats": has_stats,
+            "codeRef": code_ref
         }
         if parent_item_id:
             url = uri_join(self.base_url_v2, "item", parent_item_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 requests>=2.23.0
 six
+pytest
+delayed-assert

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 requests>=2.23.0
 six
-pytest
-delayed-assert

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests>=2.23.0
+six
+pytest
+delayed-assert

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,9 @@ from setuptools import setup, find_packages
 
 __version__ = '5.0.4'
 
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
 setup(
     name='reportportal-client',
     packages=find_packages(),
@@ -22,5 +25,5 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8'
     ],
-    install_requires=['requests>=2.4.2', 'six']
+    install_requires=requirements
 )

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,10 +1,10 @@
 """This modules includes unit tests for the service.py module."""
 
 from datetime import datetime
-from pkg_resources import DistributionNotFound
 
-from delayed_assert import assert_expectations, expect
 import pytest
+from delayed_assert import assert_expectations, expect
+from pkg_resources import DistributionNotFound
 from six.moves import mock
 
 from reportportal_client.service import (
@@ -137,7 +137,7 @@ class TestReportPortalService:
     def test_start_item(self, rp_service):
         """Test for validate start_test_item.
 
-            :param: rp_service: fixture of ReportPortal
+           :param: rp_service: fixture of ReportPortal
         """
         rp_start = rp_service.start_test_item(name="name",
                                               start_time=1591032041348,
@@ -166,11 +166,11 @@ class TestReportPortalService:
     def test_start_item_code_optional_params(self, rp_service, field_name, field_value, expected_name, expected_value):
         """Test for validate different fields in start_test_item.
 
-            :param: rp_service: fixture of ReportPortal
-            :param: field_name a name of a field bypassed to rp_service.start_test_item method
-            :param: field_value a value of a  field bypassed to rp_service.start_test_item method
-            :param: expected_name a name of a field which should be in the result JSON request
-            :param: expected_value an exact value of a field which should be in the result JSON request
+           :param: rp_service: fixture of ReportPortal
+           :param: field_name a name of a field bypassed to rp_service.start_test_item method
+           :param: field_value a value of a  field bypassed to rp_service.start_test_item method
+           :param: expected_name a name of a field which should be in the result JSON request
+           :param: expected_value an exact value of a field which should be in the result JSON request
         """
         rp_service.start_test_item(name="name", start_time=1591032041348,
                                    item_type='STORY', **{field_name: field_value})

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,10 +1,10 @@
 """This modules includes unit tests for the service.py module."""
 
 from datetime import datetime
-
-import pytest
-from delayed_assert import assert_expectations, expect
 from pkg_resources import DistributionNotFound
+
+from delayed_assert import assert_expectations, expect
+import pytest
 from six.moves import mock
 
 from reportportal_client.service import (

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -24,40 +24,40 @@ class TestServiceFunctions:
 
     def test_check_convert_to_string(self):
         """Test for support and convert strings to utf-8."""
-        expect(_convert_string("Hello world") == 'Hello world')
-        expect(lambda: isinstance(_convert_string("Hello world"), str))
+        expect(_convert_string('Hello world') == 'Hello world')
+        expect(lambda: isinstance(_convert_string('Hello world'), str))
         assert_expectations()
 
     @pytest.mark.parametrize('system', [True, False])
     def test_dict_to_payload_with_system_key(self, system):
         """Test convert dict to list of dicts with key system."""
-        initial_dict = {"aa": 1, "b": 2, "system": system}
+        initial_dict = {'aa': 1, 'b': 2, 'system': system}
         expected_list = [{'key': 'aa', 'value': '1', 'system': system},
                          {'key': 'b', 'value': '2', 'system': system}]
         assert _dict_to_payload(initial_dict) == expected_list
 
     def test_get_id(self, response):
         """Test for the get_id function."""
-        assert _get_id(response(200, {"id": 123})) == 123
+        assert _get_id(response(200, {'id': 123})) == 123
 
     def test_get_msg(self, response):
         """Test for the get_msg function."""
-        fake_json = {"id": 123}
+        fake_json = {'id': 123}
         assert _get_msg(response(200, fake_json)) == fake_json
 
     def test_get_data(self, response):
         """Test for the get_data function."""
-        fake_json = {"id": 123}
+        fake_json = {'id': 123}
         assert _get_data(response(200, fake_json)) == fake_json
 
     def test_get_json(self, response):
         """Test for the get_json function."""
-        fake_json = {"id": 123}
+        fake_json = {'id': 123}
         assert _get_json(response(200, fake_json)) == fake_json
 
     def test_get_messages(self):
         """Test for the get_messages function."""
-        data = {"responses": [{"errorCode": 422, "message": "error"}]}
+        data = {'responses': [{'errorCode': 422, 'message': 'error'}]}
         assert _get_messages(data) == ['422: error']
 
 
@@ -71,7 +71,7 @@ class TestReportPortalService:
         :param mock_get:   Mocked _get_data() function
         :param rp_service: Pytest fixture
         """
-        mock_get.return_value = {"id": 111}
+        mock_get.return_value = {'id': 111}
         launch_id = rp_service.start_launch('name', datetime.now().isoformat())
         assert launch_id == 111
 
@@ -82,10 +82,10 @@ class TestReportPortalService:
         :param mock_get:   Mocked _get_msg() function
         :param rp_service: Pytest fixture
         """
-        mock_get.return_value = {"id": 111}
+        mock_get.return_value = {'id': 111}
         _get_msg = rp_service.finish_launch(
             'name', datetime.now().isoformat())
-        assert _get_msg == {"id": 111}
+        assert _get_msg == {'id': 111}
 
     @mock.patch('platform.system', mock.Mock(return_value='linux'))
     @mock.patch('platform.machine', mock.Mock(return_value='Windows-PC'))
@@ -132,14 +132,14 @@ class TestReportPortalService:
                 == expected_result)
         assert cond
 
-    @mock.patch("reportportal_client.service._get_data",
-                mock.Mock(return_value={"id": 123}))
+    @mock.patch('reportportal_client.service._get_data',
+                mock.Mock(return_value={'id': 123}))
     def test_start_item(self, rp_service):
         """Test for validate start_test_item.
 
         :param: rp_service: fixture of ReportPortal
         """
-        rp_start = rp_service.start_test_item(name="name",
+        rp_start = rp_service.start_test_item(name='name',
                                               start_time=1591032041348,
                                               item_type='STORY')
         expected_result = dict(json={'name': 'name',
@@ -157,33 +157,33 @@ class TestReportPortalService:
         assert rp_start == 123
 
     start_item_optional = [
-        ('code_ref', '/path/to/test - test_item', "codeRef",
+        ('code_ref', '/path/to/test - test_item', 'codeRef',
          '/path/to/test - test_item'),
-        ('attributes', {'attr1': True}, "attributes",
+        ('attributes', {'attr1': True}, 'attributes',
          [{'key': 'attr1', 'value': 'True', 'system': False}])
     ]
 
     @pytest.mark.parametrize(
-        "field_name,field_value,expected_name,expected_value",
+        'field_name,field_value,expected_name,expected_value',
         start_item_optional)
-    @mock.patch("reportportal_client.service._get_data",
-                mock.Mock(return_value={"id": 123}))
+    @mock.patch('reportportal_client.service._get_data',
+                mock.Mock(return_value={'id': 123}))
     def test_start_item_code_optional_params(self, rp_service, field_name,
                                              field_value, expected_name,
                                              expected_value):
         """Test for validate different fields in start_test_item.
 
-        :param: rp_service: fixture of ReportPortal
-        :param: field_name a name of a field bypassed to
+        :param: rp_service:     fixture of ReportPortal
+        :param: field_name:     a name of a field bypassed to
         rp_service.start_test_item method
-        :param: field_value a value of a  field bypassed to
+        :param: field_value:    a value of a  field bypassed to
         rp_service.start_test_item method
-        :param: expected_name a name of a field which should be in the result
+        :param: expected_name:  a name of a field which should be in the result
         JSON request
-        :param: expected_value an exact value of a field which should be in the
-        result JSON request
+        :param: expected_value: an exact value of a field which should be in
+        the result JSON request
         """
-        rp_service.start_test_item(name="name", start_time=1591032041348,
+        rp_service.start_test_item(name='name', start_time=1591032041348,
                                    item_type='STORY',
                                    **{field_name: field_value})
         expected_result = dict(json={'name': 'name',

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -174,10 +174,14 @@ class TestReportPortalService:
         """Test for validate different fields in start_test_item.
 
         :param: rp_service: fixture of ReportPortal
-        :param: field_name a name of a field bypassed to rp_service.start_test_item method
-        :param: field_value a value of a  field bypassed to rp_service.start_test_item method
-        :param: expected_name a name of a field which should be in the result JSON request
-        :param: expected_value an exact value of a field which should be in the result JSON request
+        :param: field_name a name of a field bypassed to
+        rp_service.start_test_item method
+        :param: field_value a value of a  field bypassed to
+        rp_service.start_test_item method
+        :param: expected_name a name of a field which should be in the result
+        JSON request
+        :param: expected_value an exact value of a field which should be in the
+        result JSON request
         """
         rp_service.start_test_item(name="name", start_time=1591032041348,
                                    item_type='STORY',

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -145,7 +145,8 @@ class TestReportPortalService:
         expected_result = dict(json={'name': 'name',
                                      'description': None,
                                      'attributes': None,
-                                     'startTime': 1591032041348, 'launchUuid': 111,
+                                     'startTime': 1591032041348,
+                                     'launchUuid': 111,
                                      'type': 'STORY', 'parameters': None,
                                      'hasStats': True,
                                      'codeRef': None},
@@ -156,14 +157,20 @@ class TestReportPortalService:
         assert rp_start == 123
 
     start_item_optional = [
-        ('code_ref', '/path/to/test - test_item', "codeRef", '/path/to/test - test_item'),
-        ('attributes', {'attr1': True}, "attributes", [{'key': 'attr1', 'value': 'True', 'system': False}])
+        ('code_ref', '/path/to/test - test_item', "codeRef",
+         '/path/to/test - test_item'),
+        ('attributes', {'attr1': True}, "attributes",
+         [{'key': 'attr1', 'value': 'True', 'system': False}])
     ]
 
-    @pytest.mark.parametrize("field_name,field_value,expected_name,expected_value", start_item_optional)
+    @pytest.mark.parametrize(
+        "field_name,field_value,expected_name,expected_value",
+        start_item_optional)
     @mock.patch("reportportal_client.service._get_data",
                 mock.Mock(return_value={"id": 123}))
-    def test_start_item_code_optional_params(self, rp_service, field_name, field_value, expected_name, expected_value):
+    def test_start_item_code_optional_params(self, rp_service, field_name,
+                                             field_value, expected_name,
+                                             expected_value):
         """Test for validate different fields in start_test_item.
 
         :param: rp_service: fixture of ReportPortal
@@ -173,11 +180,13 @@ class TestReportPortalService:
         :param: expected_value an exact value of a field which should be in the result JSON request
         """
         rp_service.start_test_item(name="name", start_time=1591032041348,
-                                   item_type='STORY', **{field_name: field_value})
+                                   item_type='STORY',
+                                   **{field_name: field_value})
         expected_result = dict(json={'name': 'name',
                                      'description': None,
                                      'attributes': None,
-                                     'startTime': 1591032041348, 'launchUuid': 111,
+                                     'startTime': 1591032041348,
+                                     'launchUuid': 111,
                                      'type': 'STORY', 'parameters': None,
                                      'hasStats': True,
                                      'codeRef': None},

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -136,6 +136,7 @@ class TestReportPortalService:
                 mock.Mock(return_value={"id": 123}))
     def test_start_item(self, rp_service):
         """Test for validate start_test_item.
+
             :param: rp_service: fixture of ReportPortal
         """
         rp_start = rp_service.start_test_item(name="name",
@@ -164,7 +165,12 @@ class TestReportPortalService:
                 mock.Mock(return_value={"id": 123}))
     def test_start_item_code_optional_params(self, rp_service, field_name, field_value, expected_name, expected_value):
         """Test for validate different fields in start_test_item.
+
             :param: rp_service: fixture of ReportPortal
+            :param: field_name a name of a field bypassed to rp_service.start_test_item method
+            :param: field_value a value of a  field bypassed to rp_service.start_test_item method
+            :param: expected_name a name of a field which should be in the result JSON request
+            :param: expected_value an exact value of a field which should be in the result JSON request
         """
         rp_service.start_test_item(name="name", start_time=1591032041348,
                                    item_type='STORY', **{field_name: field_value})

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -137,7 +137,7 @@ class TestReportPortalService:
     def test_start_item(self, rp_service):
         """Test for validate start_test_item.
 
-           :param: rp_service: fixture of ReportPortal
+        :param: rp_service: fixture of ReportPortal
         """
         rp_start = rp_service.start_test_item(name="name",
                                               start_time=1591032041348,
@@ -166,11 +166,11 @@ class TestReportPortalService:
     def test_start_item_code_optional_params(self, rp_service, field_name, field_value, expected_name, expected_value):
         """Test for validate different fields in start_test_item.
 
-           :param: rp_service: fixture of ReportPortal
-           :param: field_name a name of a field bypassed to rp_service.start_test_item method
-           :param: field_value a value of a  field bypassed to rp_service.start_test_item method
-           :param: expected_name a name of a field which should be in the result JSON request
-           :param: expected_value an exact value of a field which should be in the result JSON request
+        :param: rp_service: fixture of ReportPortal
+        :param: field_name a name of a field bypassed to rp_service.start_test_item method
+        :param: field_value a value of a  field bypassed to rp_service.start_test_item method
+        :param: expected_name a name of a field which should be in the result JSON request
+        :param: expected_value an exact value of a field which should be in the result JSON request
         """
         rp_service.start_test_item(name="name", start_time=1591032041348,
                                    item_type='STORY', **{field_name: field_value})


### PR DESCRIPTION
1. Moved requirements into a separate file, since some code scan tools (E.g. fossa.com) don't have idea about different requirements declaration methods. Well, actually this point is discussable.
2. Added 'codeRef' parameter bypass and some unit-tests