### PR TITLE
Set correct requirement for six >= 1.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.23.0
-six
+six>=1.13.0
 pytest
 delayed-assert


### PR DESCRIPTION
reportportal-client 5.0.5 makes use of Mapping from six.moves.collections_ab for which six >= 1.13.0 is required

Older versions would cause 

<pre><code>
Traceback (most recent call last):
  File "test.py", line 3, in <module>
    from reportportal_client import ReportPortalService
  File "/Users/gbonetti/projects/rp-wrong-version/venv/lib/python3.7/site-packages/reportportal_client/__init__.py", line 17, in <module>
    from .service import ReportPortalService
  File "/Users/gbonetti/projects/rp-wrong-version/venv/lib/python3.7/site-packages/reportportal_client/service.py", line 25, in <module>
    from six.moves.collections_abc import Mapping
ModuleNotFoundError: No module named 'six.moves.collections_abc'
</code></pre>