### PR TITLE
Add parameters for rerun in `start_launch`

### DIFF
--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -214,6 +214,8 @@ class ReportPortalService(object):
                      description=None,
                      attributes=None,
                      mode=None,
+                     rerun=None,
+                     rerunOf=None,
                      **kwargs):
         """Start a new launch with the given parameters."""
         if attributes and isinstance(attributes, dict):
@@ -223,7 +225,9 @@ class ReportPortalService(object):
             "description": description,
             "attributes": attributes,
             "startTime": start_time,
-            "mode": mode
+            "mode": mode,
+            "rerun": rerun,
+            "rerunOf": rerunOf
         }
         url = uri_join(self.base_url_v2, "launch")
         r = self.session.post(url=url, json=data, verify=self.verify_ssl)

--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -214,7 +214,7 @@ class ReportPortalService(object):
                      description=None,
                      attributes=None,
                      mode=None,
-                     rerun=None,
+                     rerun=False,
                      rerunOf=None,
                      **kwargs):
         """Start a new launch with the given parameters."""

--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -214,7 +214,6 @@ class ReportPortalService(object):
                      description=None,
                      attributes=None,
                      mode=None,
-                     uuid=None,
                      rerun=None,
                      rerunOf=None,
                      **kwargs):
@@ -227,7 +226,6 @@ class ReportPortalService(object):
             "attributes": attributes,
             "startTime": start_time,
             "mode": mode,
-            "uuid": uuid,
             "rerun": rerun,
             "rerunOf": rerunOf
         }

--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -225,6 +225,7 @@ class ReportPortalService(object):
             "startTime": start_time,
             "mode": mode
         }
+        data.update(kwargs)
         url = uri_join(self.base_url_v2, "launch")
         r = self.session.post(url=url, json=data, verify=self.verify_ssl)
         self.launch_id = _get_id(r)
@@ -244,6 +245,7 @@ class ReportPortalService(object):
             "endTime": end_time,
             "status": status
         }
+        data.update(kwargs)
         url = uri_join(self.base_url_v1, "launch", self.launch_id, "finish")
         r = self.session.put(url=url, json=data, verify=self.verify_ssl)
         logger.debug("finish_launch - ID: %s", self.launch_id)
@@ -291,6 +293,7 @@ class ReportPortalService(object):
             "hasStats": has_stats,
             "codeRef": code_ref
         }
+        data.update(kwargs)
         if parent_item_id:
             url = uri_join(self.base_url_v2, "item", parent_item_id)
         else:
@@ -352,6 +355,7 @@ class ReportPortalService(object):
             "launchUuid": self.launch_id,
             "attributes": attributes
         }
+        data.update(kwargs)
         url = uri_join(self.base_url_v2, "item", item_id)
         r = self.session.put(url=url, json=data, verify=self.verify_ssl)
         logger.debug("finish_test_item - ID: %s", item_id)

--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -214,6 +214,7 @@ class ReportPortalService(object):
                      description=None,
                      attributes=None,
                      mode=None,
+                     uuid=None,
                      rerun=None,
                      rerunOf=None,
                      **kwargs):
@@ -226,6 +227,7 @@ class ReportPortalService(object):
             "attributes": attributes,
             "startTime": start_time,
             "mode": mode,
+            "uuid": uuid,
             "rerun": rerun,
             "rerunOf": rerunOf
         }

--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -225,7 +225,6 @@ class ReportPortalService(object):
             "startTime": start_time,
             "mode": mode
         }
-        data.update(kwargs)
         url = uri_join(self.base_url_v2, "launch")
         r = self.session.post(url=url, json=data, verify=self.verify_ssl)
         self.launch_id = _get_id(r)
@@ -245,7 +244,6 @@ class ReportPortalService(object):
             "endTime": end_time,
             "status": status
         }
-        data.update(kwargs)
         url = uri_join(self.base_url_v1, "launch", self.launch_id, "finish")
         r = self.session.put(url=url, json=data, verify=self.verify_ssl)
         logger.debug("finish_launch - ID: %s", self.launch_id)
@@ -293,7 +291,6 @@ class ReportPortalService(object):
             "hasStats": has_stats,
             "codeRef": code_ref
         }
-        data.update(kwargs)
         if parent_item_id:
             url = uri_join(self.base_url_v2, "item", parent_item_id)
         else:
@@ -355,7 +352,6 @@ class ReportPortalService(object):
             "launchUuid": self.launch_id,
             "attributes": attributes
         }
-        data.update(kwargs)
         url = uri_join(self.base_url_v2, "item", item_id)
         r = self.session.put(url=url, json=data, verify=self.verify_ssl)
         logger.debug("finish_test_item - ID: %s", item_id)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -83,7 +83,8 @@ class TestReportPortalService:
         :param rp_service: Pytest fixture
         """
         mock_get.return_value = {'id': 111}
-        launch_id = rp_service.start_launch('name', datetime.now().isoformat(), rerun=True, rerunOf="111")
+        launch_id = rp_service.start_launch('name', datetime.now().isoformat(),
+                                            rerun=True, rerunOf="111")
         assert launch_id == 111
 
     @mock.patch('reportportal_client.service._get_msg')

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -84,7 +84,6 @@ class TestReportPortalService:
         """
         mock_get.return_value = {'id': 111}
         launch_id = rp_service.start_launch('name', datetime.now().isoformat(),
-                                            uuid="111",
                                             rerun=True, rerunOf="111")
         assert launch_id == 111
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -84,6 +84,7 @@ class TestReportPortalService:
         """
         mock_get.return_value = {'id': 111}
         launch_id = rp_service.start_launch('name', datetime.now().isoformat(),
+                                            uuid="111",
                                             rerun=True, rerunOf="111")
         assert launch_id == 111
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -75,6 +75,17 @@ class TestReportPortalService:
         launch_id = rp_service.start_launch('name', datetime.now().isoformat())
         assert launch_id == 111
 
+    @mock.patch('reportportal_client.service._get_data')
+    def test_start_launch_with_rerun(self, mock_get, rp_service):
+        """Test start launch and sending request.
+
+        :param mock_get:   Mocked _get_data() function
+        :param rp_service: Pytest fixture
+        """
+        mock_get.return_value = {'id': 111}
+        launch_id = rp_service.start_launch('name', datetime.now().isoformat(), rerun=True, rerunOf="111")
+        assert launch_id == 111
+
     @mock.patch('reportportal_client.service._get_msg')
     def test_finish_launch(self, mock_get, rp_service):
         """Test finish launch and sending request.


### PR DESCRIPTION
ReportPortal now supports a functionality through the API which makes rerunning tests possible. This makes the client support it.

Covers issues #107 and #108.