### PR TITLE
Method of ReportPortalService to get launch UI URL.

### DIFF
--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -266,11 +266,7 @@ class ReportPortalService(object):
 
         :return str: UI ID of the given launch.
         """
-        launch_info = self.get_launch_info()
-        if "id" in launch_info:
-            return launch_info["id"]
-
-        raise ResponseError("No UI ID in response {0}.".format(launch_info))
+        return self.get_launch_info()["id"]
 
     def get_launch_ui_url(self):
         """Get UI URL of the current launch.

--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -249,6 +249,40 @@ class ReportPortalService(object):
         logger.debug("finish_launch - ID: %s", self.launch_id)
         return _get_msg(r)
 
+    def get_launch_info(self):
+        """Get the current launch information.
+
+        :return dict: launch information
+        """
+        url = uri_join(self.base_url_v1, "launch/uuid", self.launch_id)
+        launch_info = _get_json(self.session.get(
+            url=url, verify=self.verify_ssl))
+        logger.debug("get_launch_info - ID: %s", self.launch_id)
+        logger.debug("get_launch_info - Launch info: %s", launch_info)
+        return launch_info
+
+    def get_launch_ui_id(self):
+        """Get UI ID of the current launch.
+
+        :return str: UI ID of the given launch.
+        """
+        launch_info = self.get_launch_info()
+        if "id" in launch_info:
+            return launch_info["id"]
+
+        raise ResponseError("No UI ID in response {0}.".format(launch_info))
+
+    def get_launch_ui_url(self):
+        """Get UI URL of the current launch.
+
+        :return str: launch URL.
+        """
+        ui_id = self.get_launch_ui_id()
+        path = "ui/#{0}/launches/all/{1}".format(self.project, ui_id)
+        url = uri_join(self.endpoint, path)
+        logger.debug("get_launch_ui_url - ID: %s", self.launch_id)
+        return url
+
     def start_test_item(self,
                         name,
                         start_time,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -7,7 +7,6 @@ from delayed_assert import assert_expectations, expect
 from pkg_resources import DistributionNotFound
 from six.moves import mock
 
-from reportportal_client.errors import ResponseError
 from reportportal_client.service import (
     _convert_string,
     _dict_to_payload,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -118,24 +118,7 @@ class TestReportPortalService:
         monkeypatch.setattr(rp_service,
                             'get_launch_info',
                             mock_get_launch_info)
-        launch_ui_id = rp_service.get_launch_ui_id()
-        mock_get_launch_info.assert_called_once_with()
-        assert launch_ui_id == 113
-
-    def test_get_launch_ui_id_exception(self, rp_service, monkeypatch):
-        """Test get launch UI ID, response has no ID field.
-
-        :param rp_service:  Pytest fixture that represents ReportPortalService
-                            object with mocked session.
-        :param monkeypatch: Pytest fixture to safely set/delete an attribute
-        """
-        mock_get_launch_info = mock.Mock(return_value={'description': 'Test'})
-        monkeypatch.setattr(rp_service,
-                            'get_launch_info',
-                            mock_get_launch_info)
-
-        with pytest.raises(ResponseError):
-            rp_service.get_launch_ui_id()
+        assert rp_service.get_launch_ui_id() == 113
 
     def test_get_launch_ui_url(self, rp_service, monkeypatch):
         """Test get launch UI URL.

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -7,6 +7,7 @@ from delayed_assert import assert_expectations, expect
 from pkg_resources import DistributionNotFound
 from six.moves import mock
 
+from reportportal_client.errors import ResponseError
 from reportportal_client.service import (
     _convert_string,
     _dict_to_payload,
@@ -86,6 +87,70 @@ class TestReportPortalService:
         _get_msg = rp_service.finish_launch(
             'name', datetime.now().isoformat())
         assert _get_msg == {'id': 111}
+
+    @mock.patch('reportportal_client.service._get_json',
+                mock.Mock(return_value={'id': 112}))
+    def test_get_launch_info(self, rp_service, monkeypatch):
+        """Test get current launch information.
+
+        :param rp_service:  Pytest fixture that represents ReportPortalService
+                            object with mocked session.
+        :param monkeypatch: Pytest fixture to safely set/delete an attribute
+        """
+        mock_get = mock.Mock(return_value={'id': 112})
+        monkeypatch.setattr(rp_service.session, 'get', mock_get)
+
+        launch_id = rp_service.get_launch_info()
+        mock_get.assert_called_once_with(
+            url='{0}/launch/uuid/{1}'.format(rp_service.base_url_v1,
+                                             rp_service.launch_id),
+            verify=rp_service.verify_ssl)
+        assert launch_id == {'id': 112}
+
+    def test_get_launch_ui_id(self, rp_service, monkeypatch):
+        """Test get launch UI ID.
+
+        :param rp_service:  Pytest fixture that represents ReportPortalService
+                            object with mocked session.
+        :param monkeypatch: Pytest fixture to safely set/delete an attribute
+        """
+        mock_get_launch_info = mock.Mock(return_value={'id': 113})
+        monkeypatch.setattr(rp_service,
+                            'get_launch_info',
+                            mock_get_launch_info)
+        launch_ui_id = rp_service.get_launch_ui_id()
+        mock_get_launch_info.assert_called_once_with()
+        assert launch_ui_id == 113
+
+    def test_get_launch_ui_id_exception(self, rp_service, monkeypatch):
+        """Test get launch UI ID, response has no ID field.
+
+        :param rp_service:  Pytest fixture that represents ReportPortalService
+                            object with mocked session.
+        :param monkeypatch: Pytest fixture to safely set/delete an attribute
+        """
+        mock_get_launch_info = mock.Mock(return_value={'description': 'Test'})
+        monkeypatch.setattr(rp_service,
+                            'get_launch_info',
+                            mock_get_launch_info)
+
+        with pytest.raises(ResponseError):
+            rp_service.get_launch_ui_id()
+
+    def test_get_launch_ui_url(self, rp_service, monkeypatch):
+        """Test get launch UI URL.
+
+        :param rp_service:  Pytest fixture that represents ReportPortalService
+                            object with mocked session.
+        :param monkeypatch: Pytest fixture to safely set/delete an attribute
+        """
+        mock_get_launch_ui_id = mock.Mock(return_value=1)
+        monkeypatch.setattr(rp_service,
+                            'get_launch_ui_id',
+                            mock_get_launch_ui_id)
+        url = rp_service.get_launch_ui_url()
+        assert url == '{0}/ui/#{1}/launches/all/1'.format(rp_service.endpoint,
+                                                          rp_service.project)
 
     @mock.patch('platform.system', mock.Mock(return_value='linux'))
     @mock.patch('platform.machine', mock.Mock(return_value='Windows-PC'))


### PR DESCRIPTION
I'm not sure about name `def get_launch_info(self)`. Should I use `def get_launch_by_uuid(self)`?

The unit test also checks that session.get() has been called with the right attributes.

Implement #121
