### PR TITLE
Update helpers.py

### DIFF
--- a/reportportal_client/helpers.py
+++ b/reportportal_client/helpers.py
@@ -35,7 +35,7 @@ def gen_attributes(rp_attributes):
             key, value = rp_attr.split(':')
             attr_dict = {'key': key, 'value': value}
         except ValueError as exc:
-            logger.debug(str(exc))
+            # no need to log an error : logger.debug(str(exc))
             attr_dict = {'value': rp_attr}
 
         if all(attr_dict.values()):


### PR DESCRIPTION
This code prints :  

 [ ERROR ] not enough values to unpack (expected 2, got 1)

In report portal console for any tag without a ':' in it. 
I think this is useless. If there is a ':' , pass the tag key value, if there is no ':', only value. Where is the error ?