### PR TITLE
Implement a simple polling for get_launch_info(). 

### DIFF
--- a/reportportal_client/errors.py
+++ b/reportportal_client/errors.py
@@ -35,3 +35,7 @@ class OperationCompletionError(ResponseError):
 
     No 'message' in the json response.
     """
+
+
+class LaunchNotExistsError(Error):
+    """Launch does not exist error."""

--- a/reportportal_client/errors.py
+++ b/reportportal_client/errors.py
@@ -37,5 +37,5 @@ class OperationCompletionError(ResponseError):
     """
 
 
-class LaunchNotExistsError(Error):
-    """Launch does not exist error."""
+class LaunchExistsError(Error):
+    """Represents error in case Launch does not exist."""

--- a/reportportal_client/errors.py
+++ b/reportportal_client/errors.py
@@ -35,7 +35,3 @@ class OperationCompletionError(ResponseError):
 
     No 'message' in the json response.
     """
-
-
-class LaunchExistsError(Error):
-    """Represents error in case Launch does not exist."""

--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -287,9 +287,9 @@ class ReportPortalService(object):
         """Get UI ID of the current launch.
 
         :return str: UI ID of the given launch.
-                     0 if UI ID has not been found.
+                     None if UI ID has not been found.
         """
-        return self.get_launch_info(max_retries=max_retries).get("id", 0)
+        return self.get_launch_info(max_retries=max_retries).get("id")
 
     def get_launch_ui_url(self, max_retries=5):
         """Get UI URL of the current launch.

--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -28,7 +28,7 @@ from six.moves.collections_abc import Mapping
 from requests.adapters import HTTPAdapter
 
 from .errors import ResponseError, EntryCreatedError, \
-                    OperationCompletionError, LaunchNotExistsError
+                    OperationCompletionError, LaunchExistsError
 
 POST_LOGBATCH_RETRY_COUNT = 10
 logger = logging.getLogger(__name__)
@@ -261,7 +261,7 @@ class ReportPortalService(object):
         :return dict: launch information
         """
         if self.launch_id is None:
-            raise LaunchNotExistsError(
+            raise LaunchExistsError(
                 'Can`t request information for Launch ID "None".')
 
         url = uri_join(self.base_url_v1, "launch/uuid", self.launch_id)

--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -277,9 +277,9 @@ class ReportPortalService(object):
                          resp.status_code, resp.text)
             sleep(0.5)
         else:
-            raise ResponseError(
-                "Failed to get the launch information after {0} retries."
-                .format(max_retries))
+            logger.warning("get_launch_info - Launch info: "
+                           "Failed to fetch launch ID from the API.")
+            launch_info = {}
 
         return launch_info
 
@@ -287,15 +287,18 @@ class ReportPortalService(object):
         """Get UI ID of the current launch.
 
         :return str: UI ID of the given launch.
+                     0 if UI ID has not been found.
         """
-        return self.get_launch_info(max_retries=max_retries)["id"]
+        return self.get_launch_info(max_retries=max_retries).get("id", 0)
 
     def get_launch_ui_url(self, max_retries=5):
         """Get UI URL of the current launch.
 
-        :return str: launch URL.
+        If UI ID can`t be found after max_retries, return URL of all launches.
+
+        :return str: launch URL or all launches URL.
         """
-        ui_id = self.get_launch_ui_id(max_retries=max_retries)
+        ui_id = self.get_launch_ui_id(max_retries=max_retries) or ""
         path = "ui/#{0}/launches/all/{1}".format(self.project, ui_id)
         url = uri_join(self.endpoint, path)
         logger.debug("get_launch_ui_url - ID: %s", self.launch_id)

--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -27,8 +27,7 @@ import six
 from six.moves.collections_abc import Mapping
 from requests.adapters import HTTPAdapter
 
-from .errors import ResponseError, EntryCreatedError, \
-                    OperationCompletionError, LaunchExistsError
+from .errors import ResponseError, EntryCreatedError, OperationCompletionError
 
 POST_LOGBATCH_RETRY_COUNT = 10
 logger = logging.getLogger(__name__)
@@ -261,8 +260,7 @@ class ReportPortalService(object):
         :return dict: launch information
         """
         if self.launch_id is None:
-            raise LaunchExistsError(
-                'Can`t request information for Launch ID "None".')
+            return {}
 
         url = uri_join(self.base_url_v1, "launch/uuid", self.launch_id)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -96,8 +96,12 @@ class TestReportPortalService:
                             object with mocked session.
         :param monkeypatch: Pytest fixture to safely set/delete an attribute
         """
-        mock_get = mock.Mock(return_value={'id': 112})
+        mock_resp = mock.Mock()
+        mock_resp.status_code = 200
+
+        mock_get = mock.Mock(return_value=mock_resp)
         monkeypatch.setattr(rp_service.session, 'get', mock_get)
+        monkeypatch.setattr(rp_service, 'launch_id', '1234-cafe')
 
         launch_id = rp_service.get_launch_info()
         mock_get.assert_called_once_with(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -15,7 +15,7 @@ from reportportal_client.service import (
     _get_json,
     _get_messages,
     _get_msg,
-    ReportPortalService,
+    ReportPortalService
 )
 
 
@@ -140,8 +140,33 @@ class TestReportPortalService:
         monkeypatch.setattr(rp_service, 'launch_id', '1234')
 
         launch_info = rp_service.get_launch_info()
-        assert mock_get.call_count == 5
-        assert launch_info == {}
+        expect(mock_get.call_count == 5)
+        expect(launch_info == {})
+        assert_expectations()
+
+    @mock.patch('reportportal_client.service.sleep', mock.Mock())
+    @mock.patch('reportportal_client.service._get_json',
+                mock.Mock(return_value={'id': 112}))
+    def test_get_launch_info_1st_failed(self, rp_service, monkeypatch):
+        """Test get launch information with 1st attempt failed.
+
+        :param rp_service:  Pytest fixture that represents ReportPortalService
+                            object with mocked session.
+        :param monkeypatch: Pytest fixture to safely set/delete an attribute
+        """
+        mock_resp1 = mock.Mock()
+        mock_resp1.status_code = 404
+        mock_resp2 = mock.Mock()
+        mock_resp2.status_code = 200
+        mock_get = mock.Mock()
+        mock_get.side_effect = [mock_resp1, mock_resp2]
+        monkeypatch.setattr(rp_service.session, 'get', mock_get)
+        monkeypatch.setattr(rp_service, 'launch_id', '1234')
+
+        launch_info = rp_service.get_launch_info()
+        expect(mock_get.call_count == 2)
+        expect(launch_info == {'id': 112})
+        assert_expectations()
 
     def test_get_launch_ui_id(self, rp_service, monkeypatch):
         """Test get launch UI ID.
@@ -167,7 +192,7 @@ class TestReportPortalService:
         monkeypatch.setattr(rp_service,
                             'get_launch_info',
                             mock_get_launch_info)
-        assert rp_service.get_launch_ui_id() == 0
+        assert rp_service.get_launch_ui_id() is None
 
     def test_get_launch_ui_url(self, rp_service, monkeypatch):
         """Test get launch UI URL.


### PR DESCRIPTION
Hello, 

Improved `get_launch_info()` a little bit. Could you please let me know what do you think?

1. added the simple polling by result code 200.  
It is ok implementation? It is simple but it works. :)

2. Now it is necessary to check that launch_is is None. Without that, it would request information for ID "None" multiple times. I had to launch something so that I have added a new exception  `LaunchExistsError`. 
Is it an ok name?

3.  Should I add more debug logs like "Retry 1/5"? 

Please review, if this approach is ok, I`ll add few more unit tests to cover retries.

Implements #121.