### PR TITLE
Bump six requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.23.0
-six>=1.13.0
+six>=1.15.0
 pytest
 delayed-assert


### PR DESCRIPTION
collections_abc was added to six in 1.15 and is in use by this package but was not covered prior. Centos 8 includes six.py 1.13 causing an error