### PR TITLE
use provided launch_id if passed via kwargs

### DIFF
--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -203,7 +203,7 @@ class ReportPortalService(object):
             self.session.mount('http://', HTTPAdapter(
                 max_retries=retries, pool_maxsize=max_pool_size))
         self.session.headers["Authorization"] = "bearer {0}".format(self.token)
-        self.launch_id = None
+        self.launch_id = kwargs.get('launch_id')
         self.verify_ssl = verify_ssl
 
     def terminate(self, *args, **kwargs):


### PR DESCRIPTION
this is required by https://github.com/reportportal/agent-python-pytest/pull/240

It sets the `self.launch_id` according `kwargs['launch_id']` if provided (otherwise it sets it to `None` just as before. The change is non-breaking.