### PR TITLE
Fix the wrong item id when sending the 20 attachment batch.

### DIFF
--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -493,8 +493,6 @@ class ReportPortalService(object):
 
         attachments = []
         for log_item in self._batch_logs:
-            if item_id:
-                log_item["itemUuid"] = item_id
             log_item["launchUuid"] = self.launch_id
             attachment = log_item.get("attachment", None)
 


### PR DESCRIPTION
Hello,
When I have a test with more than 20 screenshots : 

Report_Portal_Screenshots
    Given ReportPortal Home Page
    Capture Page Screenshot
    Capture Page Screenshot
    Capture Page Screenshot
    * * * # 21 screenshots
    Capture Page Screenshot
    Capture Page Screenshot
    Capture Page Screenshot

Here is what I get in RP : 

![image](https://user-images.githubusercontent.com/78016324/105831218-be8ce480-5fc6-11eb-917a-4b264e1e7aaa.png)

When I take a look at the code, when submitting an attachment in the method log_batch, is this relevent to force the item on the 20th element pushed in the batch ? 

As : 
 - the item ID is in the content of the batch queue
 - why forcing all the attachments on the 20th element expecially  ?

When I remove these two lines, here is what I get : 

![image](https://user-images.githubusercontent.com/78016324/105831561-27745c80-5fc7-11eb-9be5-d1631e85a7b7.png)

What do you think about it ?