### PR TITLE
Restrict enum34 dependency to python 3.3 or earlier

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests>=2.23.0
 six>=1.15.0
 pytest
 delayed-assert
-enum34
+aenum


### PR DESCRIPTION
enum34 is only compatible with python 3.3 and earlier.

Installing enum34 in a python 3.4+ venv has the potential to cause `AttributeError` for other libraries when this package is installed.

The enum imports present in the package should all work fine with the built-in enum available in python 3.4+

Example of the AttributeError observed in py38 environment when enum34==1.1.10 is installed:
```
Collecting airgun
  Cloning https://github.com/SatelliteQE/airgun.git (to revision master) to /tmp/pip-install-crkp_58y/airgun_4a0d43fe511d4f739bbb9a29fae348e6
  Installing build dependencies ... error
  ERROR: Command errored out with exit status 1:
   command: /home/setup/repos/robottelo/.robottelo/bin/python3.8 /home/setup/repos/robottelo/.robottelo/lib64/python3.8/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-e1yn2_zt/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools>=40.8.0' wheel
       cwd: None
  Complete output (14 lines):
  Traceback (most recent call last):
    File "/usr/lib64/python3.8/runpy.py", line 194, in _run_module_as_main
      return _run_code(code, main_globals, None,
    File "/usr/lib64/python3.8/runpy.py", line 87, in _run_code
      exec(code, run_globals)
    File "/home/setup/repos/robottelo/.robottelo/lib64/python3.8/site-packages/pip/__main__.py", line 23, in <module>
      from pip._internal.cli.main import main as _main  # isort:skip # noqa
    File "/home/setup/repos/robottelo/.robottelo/lib64/python3.8/site-packages/pip/_internal/cli/main.py", line 5, in <module>
      import locale
    File "/usr/lib64/python3.8/locale.py", line 16, in <module>
      import re
    File "/usr/lib64/python3.8/re.py", line 145, in <module>
      class RegexFlag(enum.IntFlag):
  AttributeError: module 'enum' has no attribute 'IntFlag'
  ----------------------------------------
ERROR: Command errored out with exit status 1: /home/setup/repos/robottelo/.robottelo/bin/python3.8 /home/setup/repos/robottelo/.robottelo/lib64/python3.8/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-e1yn2_zt/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools>=40.8.0' wheel Check the logs for full command output.

```