### PR TITLE
Bearer word in Bearer tokens is case sensitive so fixing it.

### DIFF
--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -203,7 +203,7 @@ class ReportPortalService(object):
                 max_retries=retries, pool_maxsize=max_pool_size))
             self.session.mount('http://', HTTPAdapter(
                 max_retries=retries, pool_maxsize=max_pool_size))
-        self.session.headers["Authorization"] = "bearer {0}".format(self.token)
+        self.session.headers["Authorization"] = "Bearer {0}".format(self.token)
         self.launch_id = kwargs.get('launch_id')
         self.verify_ssl = verify_ssl
 


### PR DESCRIPTION
See https://github.com/reportportal/client-Python/issues/155 for more details.

This issue was found when envoy was put as a sidecar for RP's api service since
envoy doesn't accept tokens with 'bearer'.