### PR TITLE
parse optional retry parameter when starting a new child test item

### DIFF
--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -349,6 +349,7 @@ class ReportPortalService(object):
             "hasStats": has_stats,
             "codeRef": code_ref,
             "testCaseId": test_case_id,
+            "retry": kwargs.get('retry', False)
         }
         if parent_item_id:
             url = uri_join(self.base_url_v2, "item", parent_item_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aenum
+delayed_assert
 requests>=2.23.0
 six>=1.15.0

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -252,7 +252,8 @@ class TestReportPortalService:
                                      'type': 'STORY', 'parameters': None,
                                      'hasStats': True,
                                      'codeRef': None,
-                                     'testCaseId': None},
+                                     'testCaseId': None,
+                                     'retry': False},
                                url='http://endpoint/api/v2/project/item',
                                verify=True)
 
@@ -297,7 +298,8 @@ class TestReportPortalService:
                                      'type': 'STORY', 'parameters': None,
                                      'hasStats': True,
                                      'codeRef': None,
-                                     'testCaseId': None},
+                                     'testCaseId': None,
+                                     'retry': False},
                                url='http://endpoint/api/v2/project/item',
                                verify=True)
         expected_result['json'][expected_name] = expected_value


### PR DESCRIPTION
This is required by a [retry](https://github.com/reportportal/documentation/blob/master/src/md/src/DevGuides/retries.md#retries-reporting) workflow