### PR TITLE
Allow setting `HTTPAdapter.pool_maxsize` without `retries`

### DIFF
--- a/reportportal_client/client.py
+++ b/reportportal_client/client.py
@@ -15,7 +15,7 @@
 
 import logging
 import requests
-from requests.adapters import HTTPAdapter, Retry
+from requests.adapters import HTTPAdapter, Retry, DEFAULT_RETRIES
 
 from ._local import set_current
 from .core.rp_requests import (
@@ -100,16 +100,16 @@ class RPClient(object):
         self.step_reporter = StepReporter(self)
         self._item_stack = []
         self.mode = mode
-        if retries:
-            retry_strategy = Retry(
-                total=retries,
-                backoff_factor=0.1,
-                status_forcelist=[429, 500, 502, 503, 504]
-            )
-            self.session.mount('https://', HTTPAdapter(
-                max_retries=retry_strategy, pool_maxsize=max_pool_size))
-            self.session.mount('http://', HTTPAdapter(
-                max_retries=retry_strategy, pool_maxsize=max_pool_size))
+
+        retry_strategy = Retry(
+            total=retries,
+            backoff_factor=0.1,
+            status_forcelist=[429, 500, 502, 503, 504]
+        ) if retries else DEFAULT_RETRIES
+        self.session.mount('https://', HTTPAdapter(
+            max_retries=retry_strategy, pool_maxsize=max_pool_size))
+        self.session.mount('http://', HTTPAdapter(
+            max_retries=retry_strategy, pool_maxsize=max_pool_size))
         self.session.headers['Authorization'] = 'bearer {0}'.format(self.token)
 
         self._log_manager = LogManager(

--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -182,7 +182,7 @@ class ReportPortalService(object):
                  log_batch_size=20,
                  is_skipped_an_issue=True,
                  verify_ssl=True,
-                 retries=None,
+                 retries=0,
                  max_pool_size=50,
                  http_timeout=(10, 10),
                  **kwargs):
@@ -214,7 +214,7 @@ class ReportPortalService(object):
         self.http_timeout = http_timeout
 
         self.session = requests.Session()
-        if retries:
+        if retries or max_pool_size:
             self.session.mount('https://', HTTPAdapter(
                 max_retries=retries, pool_maxsize=max_pool_size))
             self.session.mount('http://', HTTPAdapter(

--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -182,7 +182,7 @@ class ReportPortalService(object):
                  log_batch_size=20,
                  is_skipped_an_issue=True,
                  verify_ssl=True,
-                 retries=0,
+                 retries=None,
                  max_pool_size=50,
                  http_timeout=(10, 10),
                  **kwargs):
@@ -214,7 +214,7 @@ class ReportPortalService(object):
         self.http_timeout = http_timeout
 
         self.session = requests.Session()
-        if retries or max_pool_size:
+        if retries:
             self.session.mount('https://', HTTPAdapter(
                 max_retries=retries, pool_maxsize=max_pool_size))
             self.session.mount('http://', HTTPAdapter(


### PR DESCRIPTION
Fix this issue: #200