### PR TITLE
pass verify_ssl parameter also to LogManager instance

### DIFF
--- a/reportportal_client/client.py
+++ b/reportportal_client/client.py
@@ -120,7 +120,8 @@ class RPClient(object):
         self._log_manager = LogManager(
             self.endpoint, self.session, self.api_v2, self.launch_id,
             self.project, max_entry_number=log_batch_size,
-            max_payload_size=log_batch_payload_size)
+            max_payload_size=log_batch_payload_size,
+            verify_ssl=self.verify_ssl)
 
     def finish_launch(self,
                       end_time,


### PR DESCRIPTION
It looks like this was missed and it resulted in some errors while trying to interact with an instance that was using a self-signed certificate.