### PR TITLE
Updated get method to not pass body as a blank json

### DIFF
--- a/reportportal_client/client.py
+++ b/reportportal_client/client.py
@@ -274,7 +274,7 @@ class RPClient(object):
         :return: HTTP response in dictionary
         """
         url = uri_join(self.base_url_v1, 'settings')
-        response = HttpRequest(self.session.get, url=url, json={},
+        response = HttpRequest(self.session.get, url=url,
                                verify_ssl=self.verify_ssl).make()
         return response.json if response else None
 


### PR DESCRIPTION
if you host RP behind an https corporate proxy, some rules on the edge layer might prevent requests from entering the system.

https://www.rfc-editor.org/rfc/rfc7231#page-24

```A payload within a GET request message has no defined semantics; sending a payload body on a GET request might cause some existing implementations to reject the request.```