### PR TITLE
Fixing Record pathnames are incorrect on python3.11

### DIFF
--- a/reportportal_client/logs/__init__.py
+++ b/reportportal_client/logs/__init__.py
@@ -58,6 +58,8 @@ class RPLogger(logging.getLoggerClass()):
             # exception on some versions of IronPython. We trap it here so that
             # IronPython can use logging.
             try:
+                if sys.version_info >= (3, 11):
+                    kwargs.setdefault('stacklevel', 2)
                 if 'stacklevel' in kwargs:
                     fn, lno, func, sinfo = \
                         self.findCaller(stack_info, kwargs['stacklevel'])

--- a/tests/logs/test_rp_logger.py
+++ b/tests/logs/test_rp_logger.py
@@ -40,6 +40,7 @@ def test_record_make(logger_handler):
     logger.info('test_log')
     record = verify_record(logger_handler)
     assert not getattr(record, 'attachment')
+    assert record.pathname == __file__
 
 
 @mock.patch('reportportal_client.logs.logging.Logger.handle')
@@ -86,3 +87,4 @@ def test_stacklevel_record_make(logger_handler):
                      stack_info=inspect.stack(), stacklevel=2)
     record = verify_record(logger_handler)
     assert record.stack_info.endswith("logger.error('test_log', exc_info=RuntimeError('test'),")
+    assert record.pathname == __file__


### PR DESCRIPTION
Fixes #234 

adding file location assertion to test_rp_logger, and fixing for 3.11
