### PR TITLE
Fix ssl context when certificate is provided

### DIFF
--- a/reportportal_client/aio/client.py
+++ b/reportportal_client/aio/client.py
@@ -161,9 +161,9 @@ class Client:
             ssl_config = False
         else:
             if type(self.verify_ssl) is str:
-                ssl_config = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH, cafile=self.verify_ssl)
+                ssl_config = ssl.create_default_context(ssl.Purpose.SERVER_AUTH, cafile=self.verify_ssl)
             else:
-                ssl_config = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH, cafile=certifi.where())
+                ssl_config = ssl.create_default_context(ssl.Purpose.SERVER_AUTH, cafile=certifi.where())
 
         connection_params = {
             'ssl': ssl_config,


### PR DESCRIPTION
I have a tool that (reliably) uploads test results to our RP instance.

We recently added https certifacates to our servers.
But trying to use `verify_ssl='C:/GIT/MyProject/myCert.crt'` with the ASYNC_THREAD client resulted in the following error:

```python
ReportPortal None request failed
Traceback (most recent call last):
  File "C:\Users\xxx\Desktop\Python3\Python311\Lib\site-packages\aiohttp\connector.py", line 1025, in _wrap_create_connection
    return await self._loop.create_connection(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\xxx\Desktop\Python3\Python311\Lib\asyncio\base_events.py", line 1113, in create_connection
    transport, protocol = await self._create_connection_transport(
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\xxx\Desktop\Python3\Python311\Lib\asyncio\base_events.py", line 1137, in _create_connection_transport
    transport = self._make_ssl_transport(
                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\xxx\Desktop\Python3\Python311\Lib\asyncio\proactor_events.py", line 655, in _make_ssl_transport
    ssl_protocol = sslproto.SSLProtocol(
                   ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\xxx\Desktop\Python3\Python311\Lib\asyncio\sslproto.py", line 330, in __init__
    self._sslobj = self._sslcontext.wrap_bio(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\xxx\Desktop\Python3\Python311\Lib\ssl.py", line 531, in wrap_bio
    return self.sslobject_class._create(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\xxx\Desktop\Python3\Python311\Lib\ssl.py", line 870, in _create
    sslobj = context._wrap_bio(
             ^^^^^^^^^^^^^^^^^^
ssl.SSLError: Cannot create a client socket with a PROTOCOL_TLS_SERVER context (_ssl.c:809)

Traceback (most recent call last):
  File "C:\Users\xxx\Desktop\Python3\Python311\Lib\site-packages\reportportal_client\core\rp_requests.py", line 168, in make
    return AsyncRPResponse(await self.session_method(url, data=data, json=json))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\xxx\Desktop\Python3\Python311\Lib\site-packages\reportportal_client\_internal\aio\http.py", line 107, in __request
    raise exc
  File "C:\Users\xxx\Desktop\Python3\Python311\Lib\site-packages\reportportal_client\_internal\aio\http.py", line 100, in __request
    result = await method(url, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\xxx\Desktop\Python3\Python311\Lib\site-packages\aiohttp\client.py", line 581, in _request
    conn = await self._connector.connect(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\xxx\Desktop\Python3\Python311\Lib\site-packages\aiohttp\connector.py", line 544, in connect
    proto = await self._create_connection(req, traces, timeout)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\xxx\Desktop\Python3\Python311\Lib\site-packages\aiohttp\connector.py", line 944, in _create_connection
    _, proto = await self._create_direct_connection(req, traces, timeout)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\xxx\Desktop\Python3\Python311\Lib\site-packages\aiohttp\connector.py", line 1257, in _create_direct_connection
    raise last_exc
  File "C:\Users\xxx\Desktop\Python3\Python311\Lib\site-packages\aiohttp\connector.py", line 1226, in _create_direct_connection
    transp, proto = await self._wrap_create_connection(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\xxx\Desktop\Python3\Python311\Lib\site-packages\aiohttp\connector.py", line 1029, in _wrap_create_connection
    raise ClientConnectorSSLError(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorSSLError: Cannot connect to host myNewServer.internal.network:443 ssl:default [Cannot create a client socket with a PROTOCOL_TLS_SERVER context (_ssl.c:809)]
```

--- 

I tracked down the issue to `reportportal_client\aio\client.py` where we create the ssl context with `ssl.create_default_context(ssl.Purpose.CLIENT_AUTH, cafile=self.verify_ssl)`

Using the `purpose=ssl.Purpose.CLIENT_AUTH` seems to be the wrong and a quite common mistake.
According to this [post on stackoverflow](https://stackoverflow.com/questions/76298101/cannot-create-a-client-socket-with-a-protocol-tls-server-context-while-trying-to) and the documentation of [ssl library](https://docs.python.org/3/library/ssl.html#ssl.Purpose.SERVER_AUTH) we must:
- Use SERVER_AUTH for client-side sockets
- Use CLIENT_AUTH for server-side sockets

As we are a client connecting to the RP-Servers, we have to use `purpose=ssl.Purpose.SERVER_AUTH` (we as a client want to authenticate the server with the certificate)