### PR TITLE
change timestamp to microseconds format

### DIFF
--- a/reportportal_client/helpers/common_helpers.py
+++ b/reportportal_client/helpers/common_helpers.py
@@ -25,6 +25,7 @@ import uuid
 from platform import machine, processor, system
 from types import MappingProxyType
 from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, Tuple, TypeVar, Union
+from datetime import datetime, timezone
 
 from reportportal_client.core.rp_file import RPFile
 
@@ -276,8 +277,9 @@ def verify_value_length(attributes: Optional[Union[List[dict], dict]]) -> Option
 
 
 def timestamp() -> str:
-    """Return string representation of the current time in milliseconds."""
-    return str(int(time.time() * 1000))
+    """Return string representation of the current time in microseconds."""
+    now = datetime.now(timezone.utc)
+    return now.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
 def uri_join(*uri_parts: str) -> str:

--- a/tests/logs/test_rp_log_handler.py
+++ b/tests/logs/test_rp_log_handler.py
@@ -68,7 +68,7 @@ def test_emit_simple(mocked_handle):
     call_args = mock_client.log.call_args[0]
     call_kwargs = mock_client.log.call_args[1]
 
-    assert re.match("^[0-9]+$", call_args[0])
+    assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$", call_args[0])
     assert test_message == call_args[1]
     assert call_kwargs["level"] == "INFO"
     assert not call_kwargs["attachment"]


### PR DESCRIPTION
The reportportal server supports receiving logs with microsecond resolution, but currently the logs send the `time` value in milliseconds in the python client, while other languages like .NET and Java support this.
This causes problems when sending logs from python, as logs with the same timestamp appear out-of-order.

Originally, I tried to change the `timestamp` to multiply by 1_000_000, and the string was sent correctly from the python client, but the timestamp was corrupted in the reportportal postgres DB. So I switched to this solution:

In the server side, the [commons-reporting](https://github.com/reportportal/commons-reporting/blob/56e31137dcda86ea536302f5ba50c89ebe483874/src/main/java/com/epam/ta/reportportal/ws/reporting/databind/MultiFormatDateDeserializer.java#L40) logic knows how to handle multiple formats of `time`, so I changed to a format that includes microseconds. This works great.

![image](https://github.com/user-attachments/assets/31203a43-72d4-4242-8e11-9b00360afb3d)
