### PR TITLE
Fixing the license id

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email="support@reportportal.io",
     url="https://github.com/reportportal/client-Python",
     download_url=("https://github.com/reportportal/client-Python/" "tarball/%s" % __version__),
-    license="Apache 2.0.",
+    license="Apache-2.0",
     keywords=["testing", "reporting", "reportportal", "client"],
     classifiers=[
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
The license id has an unusual '.' prefix on it. I've dropped that, but also switched it to the official "Apache-2.0" SPDX ID while I'm at it. 